### PR TITLE
Update `pom.xml` for release and add maven publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Maven Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  release:
+
+    runs-on: ubuntu-latest
+
+    environment: OSSBUILD
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Get Maven Project Version
+        run: |
+          echo "PROJECT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec  --file pom.xml)" >> $GITHUB_ENV
+          cat $GITHUB_ENV
+
+      - name: Install GPG Secret Key
+        id: install-secret-key
+        run: |
+          cat <(echo -e "${{ secrets.GPG_SECRET_KEY }}") | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+  
+      - name: Install GPG Public Key
+        id: install-pulic-key
+        run: |
+          cat <(echo -e "${{ secrets.GPG_PUBLIC_KEY }}") | gpg --batch --import
+          gpg --list-public-keys --keyid-format LONG
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+          server-id: ossrh
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_TOKEN
+          gpg-passphrase: GPG_PASSPHRASE
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Set Test Secrets
+        run: |
+          cp ${{ env.CONFIG_PROPERTIES_SAMPLE }} ${{ env.CONFIG_PROPERTIES }}
+          sed -i 's/^IBMI_HOST=/IBMI_HOST=${{ secrets.IBMI_HOST }}/' ${{ env.CONFIG_PROPERTIES }}
+          sed -i 's/^IBMI_USER=/IBMI_USER=${{ secrets.IBMI_USER }}/' ${{ env.CONFIG_PROPERTIES }}
+          sed -i 's/^IBMI_PASSWORD=/IBMI_PASSWORD=${{ secrets.IBMI_PASSWORD }}/' ${{ env.CONFIG_PROPERTIES }}
+          sed -i 's/^IBMI_PORT=/IBMI_PORT=${{ secrets.IBMI_PORT }}/' ${{ env.CONFIG_PROPERTIES }}
+
+      - name: Publish Maven Package
+        run: mvn -B clean deploy --file pom.xml
+
+      - name: List Target Directory
+        run: ls -l target
+
+      - name: Copy Artifacts to Staging Directory
+        run: mkdir staging && cp target/*.jar staging
+
+      - name: Create Bundle .zip
+        run: cd staging && zip mapapire-java-${{ env.PROJECT_VERSION }}.zip *.jar && cd ..
+
+      - name: Get Release
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload JAR to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./mapapire-java-${{ env.PROJECT_VERSION }}.jar
+          asset_name: mapapire-java-${{ env.PROJECT_VERSION }}.jar
+          asset_content_type: application/zip
+
+      - name: Upload ZIP to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./mapapire-java-${{ env.PROJECT_VERSION }}.zip
+          asset_name: mapapire-java-${{ env.PROJECT_VERSION }}.zip
+          asset_content_type: application/zip

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.github.mapapire</groupId>
-  <artifactId>mapapire-java</artifactId>
+  <groupId>io.github.mapapire-ibmi</groupId>
+  <artifactId>mapapire-sdk</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,57 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>io.github.mapapire</groupId>
   <artifactId>mapapire-java</artifactId>
   <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Mapepire Java</name>
+  <description>The Mapepire Java client SDK provides a new and convenient way to access Db2 on IBM i</description>
+  <url>https://github.com/Mapepire-IBMi/mapepire-java</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://raw.githubusercontent.com/Mapepire-IBMi/mapepire-java/main/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Sanjula Ganepola</name>
+      <email>sanjula.ganepola@ibm.com</email>
+      <organization>IBM</organization>
+      <organizationUrl>http://www.ibm.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Jesse Gorzinski</name>
+      <email>jgorzins@us.ibm.com</email>
+      <organization>IBM</organization>
+      <organizationUrl>http://www.ibm.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/Mapepire-IBMi/mapepire-java.git</connection>
+    <developerConnection>scm:git:ssh://github.com:Mapepire-IBMi/mapepire-java.git</developerConnection>
+    <url>https://github.com/Mapepire-IBMi/mapepire-java</url>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -20,6 +69,7 @@
     <jacoco.unit-tests.limit.class-complexity>20</jacoco.unit-tests.limit.class-complexity>
     <jacoco.unit-tests.limit.method-complexity>5</jacoco.unit-tests.limit.method-complexity>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.java-websocket</groupId>
@@ -44,6 +94,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -170,8 +221,60 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.8.0</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.2.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.7.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
+
   <reporting>
     <plugins>
       <plugin>


### PR DESCRIPTION
### Changes
- Add project info to `pom.xml`
- Add new plugins: `maven-source-plugin`, `maven-javadoc-plugin`, `maven-gpg-plugin`, `nexus-staging-maven-plugin`
- Add maven publishing workflow

### TODO
- [ ] Setup on OSSRH
- [x] Add the following repository secrets:
  - `OSSRH_USERNAME`
  - `OSSRH_TOKEN`
  - `GPG_SECRET_KEY`
  - `GPG_PUBLIC_KEY`
  - `GPG_PASSPHRASE`

@ThePrez The changes in this PR follow closely with what is done in the [JTOpen](https://github.com/IBM/JTOpen) repo. There were some slight differences based on what was explained on https://central.sonatype.org/publish/publish-guide