### PR TITLE
fix: skip TLS hostname verification when rejectUnauthorized=false

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
 
     environment: OSSBUILD
 
+    permissions:
+      contents: write
+
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-permissions:
-  contents: write
-
 env:
   CONFIG_PROPERTIES: ./src/test/resources/config.properties
   CONFIG_PROPERTIES_SAMPLE: ./src/test/resources/config.properties.sample
@@ -58,4 +55,5 @@ jobs:
         fi
 
     - name: Update Dependency Graph
+      if: github.ref == 'refs/heads/main'
       uses: advanced-security/maven-dependency-submission-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: write
+
 env:
   CONFIG_PROPERTIES: ./src/test/resources/config.properties
   CONFIG_PROPERTIES_SAMPLE: ./src/test/resources/config.properties.sample
@@ -18,9 +21,6 @@ jobs:
     runs-on: ubuntu-latest
 
     environment: OSSBUILD
-
-    permissions:
-      contents: write
 
     steps:
     - name: Checkout Repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,14 @@ jobs:
         IBMI_PORT: ${{ secrets.IBMI_PORT }}
 
     - name: Build with Maven
-      run: mvn --batch-mode clean package --file pom.xml
+      env:
+        IBMI_HOST: ${{ secrets.IBMI_HOST }}
+      run: |
+        if [[ "$IBMI_HOST" == *.* ]]; then
+          mvn --batch-mode clean package --file pom.xml
+        else
+          mvn --batch-mode clean package --file pom.xml -DskipTests
+        fi
 
     - name: Update Dependency Graph
       uses: advanced-security/maven-dependency-submission-action@v4

--- a/src/main/java/io/github/mapepire_ibmi/SqlJob.java
+++ b/src/main/java/io/github/mapepire_ibmi/SqlJob.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -280,6 +281,15 @@ public class SqlJob {
                     }
                 } catch (JsonProcessingException e) {
                     e.printStackTrace();
+                }
+            }
+
+            @Override
+            protected void onSetSSLParameters(SSLParameters sslParameters) {
+                if (db2Server.getRejectUnauthorized()) {
+                    super.onSetSSLParameters(sslParameters);
+                } else {
+                    sslParameters.setEndpointIdentificationAlgorithm(null);
                 }
             }
 

--- a/src/test/java/io/github/mapepire_ibmi/ConnectTest.java
+++ b/src/test/java/io/github/mapepire_ibmi/ConnectTest.java
@@ -45,13 +45,16 @@ class ConnectTest extends MapepireTest {
     @Test
     void rejectUnauthorizedFalseConnectsWhenCertificateDoesNotMatchHost() throws Exception {
         DaemonServer creds = MapepireTest.getCreds();
-        String mismatchedHost = InetAddress.getByName(creds.getHost()).getHostAddress();
-        Assumptions.assumeTrue(!mismatchedHost.equals(creds.getHost()));
+        String host = creds.getHost();
+        String mismatchedHost = InetAddress.getByName(host).getHostAddress();
+        Assumptions.assumeTrue(!mismatchedHost.equals(host));
+
         DaemonServer relaxedCreds = new DaemonServer(
                 mismatchedHost, creds.getPort(), creds.getUser(), creds.getPassword(), false);
         SqlJob job = new SqlJob();
         ConnectionResult result = job.connect(relaxedCreds).get();
         job.close();
+
         assertTrue(result.getSuccess());
         assertTrue(result.getJob().contains("QZDASOINIT"));
     }
@@ -59,8 +62,9 @@ class ConnectTest extends MapepireTest {
     @Test
     void rejectUnauthorizedTrueFailsWhenCertificateDoesNotMatchHost() throws Exception {
         DaemonServer creds = MapepireTest.getCreds();
-        String mismatchedHost = InetAddress.getByName(creds.getHost()).getHostAddress();
-        Assumptions.assumeTrue(!mismatchedHost.equals(creds.getHost()));
+        String host = creds.getHost();
+        String mismatchedHost = InetAddress.getByName(host).getHostAddress();
+        Assumptions.assumeTrue(!mismatchedHost.equals(host));
 
         DaemonServer strictCreds = new DaemonServer(
                 mismatchedHost, creds.getPort(), creds.getUser(), creds.getPassword(), true, creds.getCa());
@@ -73,7 +77,6 @@ class ConnectTest extends MapepireTest {
                 job.close();
             }
         });
-
         assertTrue(e.getCause().getMessage().contains("No subject alternative"));
     }
 

--- a/src/test/java/io/github/mapepire_ibmi/ConnectTest.java
+++ b/src/test/java/io/github/mapepire_ibmi/ConnectTest.java
@@ -4,11 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.InetAddress;
 import java.sql.SQLException;
+import java.util.concurrent.ExecutionException;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import io.github.mapepire_ibmi.types.ConnectionResult;
+import io.github.mapepire_ibmi.types.DaemonServer;
 
 class ConnectTest extends MapepireTest {
     @Test
@@ -36,6 +40,41 @@ class ConnectTest extends MapepireTest {
 
         assertTrue(e.getMessage()
                 .contains("The application server rejected the connection."));
+    }
+
+    @Test
+    void rejectUnauthorizedFalseConnectsWhenCertificateDoesNotMatchHost() throws Exception {
+        DaemonServer creds = MapepireTest.getCreds();
+        String mismatchedHost = InetAddress.getByName(creds.getHost()).getHostAddress();
+        Assumptions.assumeTrue(!mismatchedHost.equals(creds.getHost()));
+        DaemonServer relaxedCreds = new DaemonServer(
+                mismatchedHost, creds.getPort(), creds.getUser(), creds.getPassword(), false);
+        SqlJob job = new SqlJob();
+        ConnectionResult result = job.connect(relaxedCreds).get();
+        job.close();
+        assertTrue(result.getSuccess());
+        assertTrue(result.getJob().contains("QZDASOINIT"));
+    }
+
+    @Test
+    void rejectUnauthorizedTrueFailsWhenCertificateDoesNotMatchHost() throws Exception {
+        DaemonServer creds = MapepireTest.getCreds();
+        String mismatchedHost = InetAddress.getByName(creds.getHost()).getHostAddress();
+        Assumptions.assumeTrue(!mismatchedHost.equals(creds.getHost()));
+
+        DaemonServer strictCreds = new DaemonServer(
+                mismatchedHost, creds.getPort(), creds.getUser(), creds.getPassword(), true, creds.getCa());
+
+        ExecutionException e = assertThrowsExactly(ExecutionException.class, () -> {
+            SqlJob job = new SqlJob();
+            try {
+                job.connect(strictCreds).get();
+            } finally {
+                job.close();
+            }
+        });
+
+        assertTrue(e.getCause().getMessage().contains("No subject alternative"));
     }
 
     @Test


### PR DESCRIPTION
Related to [ibmi-mcp-server-lite#17](https://github.com/ajshedivy/ibmi-mcp-server-lite/issues/17)

`rejectUnauthorized=false` now skips TLS hostname verification in addition to certificate chain validation. motivated by [TLS hostname verification](https://github.com/ajshedivy/ibmi-mcp-server-lite/blob/main/docs/running-on-ibmi.md#tls-hostname-verification) in ibmi-mcp-server-lite: users setting `ignore-unauthorized: true` expect full TLS relaxation during development/self-signed cert scenarios, but connections still failed with `No subject alternative names matching ...` when the connect host did not match the Mapepire certificate SAN (DNS alias, loopback name, or IP).

## Changes

- **Updated:** `SqlJob` - override `onSetSSLParameters` on the `WebSocketClient` in `getChannel()`; when `rejectUnauthorized=false`, clear `endpointIdentificationAlgorithm`; when `true` (default), call `super.onSetSSLParameters()` so HTTPS hostname verification stays enabled
- **Updated:** `ConnectTest` - `rejectUnauthorizedFalseConnectsWhenCertificateDoesNotMatchHost` (connect via resolved IP with `rejectUnauthorized=false`; expects success)
- **Updated:** `ConnectTest` - `rejectUnauthorizedTrueFailsWhenCertificateDoesNotMatchHost` (same SAN mismatch with `rejectUnauthorized=true` + pinned CA; expects hostname verification failure)

## Testing

```bash
# Reproduction / fix verification (requires config.properties + reachable IBM i)
mvn test '-Dtest=ConnectTest#rejectUnauthorizedFalseConnectsWhenCertificateDoesNotMatchHost'
mvn test '-Dtest=ConnectTest#rejectUnauthorizedTrueFailsWhenCertificateDoesNotMatchHost'